### PR TITLE
Fix: Correct YAML syntax for volumes in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,7 @@ services:
       # The application's vite.config.js is set up to read GEMINI_API_KEY
       # and make it available as process.env.GEMINI_API_KEY
       - GEMINI_API_KEY=${GEMINI_API_KEY}
-    volumes:
-      # For development, you might want to mount your source code
-      # For production, it's better to rely on the code baked into the image
+    # volumes:
       # Example for development (uncomment if needed, and ensure paths are correct):
       # - .:/app
       # - /app/node_modules # Exclude node_modules from being overwritten by the mount


### PR DESCRIPTION
The 'volumes' key in docker-compose.yml was causing a parsing error when all its child list items were commented out. This commit fixes the issue by commenting out the 'volumes:' key itself, ensuring the file is syntactically correct when no volumes are actively defined.

This makes the example volume configuration clearly optional and prevents errors during docker-compose validation when the examples are not in use.

---
name: Pull Request
about: Propose changes to the project
title: ''
labels: ''
assignees: ''

---

**Related Issue**
Please link to the issue that this pull request addresses. E.g., "Closes #123"

**Description**
A clear and concise description of the changes being made.

**Changes Made**
- [ ] Change 1
- [ ] Change 2
- [ ] ...

**Screenshots (if applicable)**
If the changes include UI modifications, please include screenshots or GIFs.

**Testing**
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
```
